### PR TITLE
Key Usage Policy Identifiers

### DIFF
--- a/hcert_spec.md
+++ b/hcert_spec.md
@@ -269,6 +269,14 @@ The Secretarial shall also:
 * Maintain a similar set of lists with 'test' certificates
 * Maintain a set of test certificates - at least one for each country.
 
+## Key Usage Policy Identifiers
+The document signing certificate MAY contain Extended key usage extension fields; these being:
+
+* OID 1.3.6.1.4.1.0.1847.2021.1.1 valid for test
+* OID 1.3.6.1.4.1.0.1847.2021.1.2 valid for vaccinations
+* OID 1.3.6.1.4.1.0.1847.2021.1.3 valid for recovery
+
+The DSC may contain an extended key usage extension with one or more key usage policy identifiers that constrain the types of HCERTs this certificate is allowed to verify. If present the verifiers SHALL verify the key usage against the stored HCERT. In absence of any key usage extension, this certificate can be used to validate any type of HCERT. Other documents MAY define relevant extended key usage policy identifiers used with validation of HCERTs.
 
 _________________
 

--- a/hcert_spec.md
+++ b/hcert_spec.md
@@ -269,15 +269,6 @@ The Secretarial shall also:
 * Maintain a similar set of lists with 'test' certificates
 * Maintain a set of test certificates - at least one for each country.
 
-## Key Usage Policy Identifiers
-
-The document signing certificate MAY contain Extended key usage extension fields; these being:
-
-* OID 1.3.6.1.4.1.0.1847.2021.1.1        valid for test
-* OID 1.3.6.1.4.1.0.1847.2021.1.2        valid for vaccinations
-* OID 1.3.6.1.4.1.0.1847.2021.1.3        valid for recovery
-
-If none of these OIDs are present the document shall be considered valid for all three.
 
 _________________
 


### PR DESCRIPTION
unless there is a deeper rationale behind those OIDs, which is not defined in the text, I would drop them.
If there is rationale, the text would still need to explain this rationale and also define rules for validators.

related to #33 