### PR TITLE
URI-preamble

### DIFF
--- a/hcert_spec.md
+++ b/hcert_spec.md
@@ -136,7 +136,7 @@ In order to better handle legacy equipment designed to operate on ASCII payloads
 
 The QR format as defined in (ISO/IEC 18004:2015) SHALL be used for 2D barcode generation. An error correction rate of ‘Q’ (around 25%) is RECOMMENDED.  The Alphanumeric (Mode 2/QR Code symbols 0010) MUST be used in conjunction with Base45. 
 
-In order for Verifiers to be able to detect the type of data encoded and to select the proper decoding and processing scheme, the base45 encoded data (as per this specification) SHALL be prefixed by the Context Identifier string "HC1". Future versions of this specification that impact backwards-compatibilty SHALL define a new Context Identifier, whereas the character following "HC" SHALL be taken from the character set [1-9A-Z]. The order of increments is defined to be in that order, i.e., first [1-9] and then [A-Z].
+In order for Verifiers to be able to detect the type of data encoded and to select the proper decoding and processing scheme, the base45 encoded data (as per this specification) SHALL be prefixed by the Context Identifier string "HC1:". Future versions of this specification that impact backwards-compatibilty SHALL define a new Context Identifier, whereas the character following "HC" SHALL be taken from the character set [1-9A-Z]. The order of increments is defined to be in that order, i.e., first [1-9] and then [A-Z].
 
 The optical code is RECOMMENDED to be rendered on the presentation media with a diagonal size between 35 mm and 60 mm to accommodate readers with fixed optics where the presentation media is required to be placed on the surface of the reader.
 


### PR DESCRIPTION
Use HC1: as preamble to mimic a URI scheme and prohibit automatic searches when scanned. Also has the benefit that verification apps can register HC1 as a URI scheme and open automatically when the HCERT is scanned.

closes #44 

This does not address the user information properties, but fixes the leakage issue with a single byte.

Kudos to @SZoerner for identifying this issue and putting us on the right track!