### PR TITLE
Follow suggestion of RFC8949 section 3.4.2 to use integer timestamps

### DIFF
--- a/hcert_spec.md
+++ b/hcert_spec.md
@@ -94,13 +94,13 @@ The Issuer (`iss`) claim is a string value that MAY optionally hold the ISO 3166
 
 #### 3.3.5 Expiration Time
 
-The Expiration Time (`exp`) claim SHALL hold a timestamp in the NumericDate format (as specified in [RFC 8392](https://tools.ietf.org/html/rfc8392) section 2) indicating for how long this particular signature over the Payload SHALL be considered valid, after which a Verifier MUST reject the Payload as expired. The purpose of the expiry parameter is to force a limit of the validity period of the health certificate. The Claim Key 4 is used to identify this claim.
+The Expiration Time (`exp`) claim SHALL hold a timestamp in the integer NumericDate format (as specified in [RFC 8392](https://tools.ietf.org/html/rfc8392) section 2) indicating for how long this particular signature over the Payload SHALL be considered valid, after which a Verifier MUST reject the Payload as expired. The purpose of the expiry parameter is to force a limit of the validity period of the health certificate. The Claim Key 4 is used to identify this claim.
 
 The Expiration Time MUST not exceed the validity period of the DSC.
 
 #### 3.3.6 Issued At
 
-The Issued At (`iat`) claim SHALL hold a timestamp in the NumericDate format (as specified in [RFC 8392](https://tools.ietf.org/html/rfc8392) section 2) indicating the time when the health certificate was created. 
+The Issued At (`iat`) claim SHALL hold a timestamp in the integer NumericDate format (as specified in [RFC 8392](https://tools.ietf.org/html/rfc8392) section 2) indicating the time when the health certificate was created. 
 
 The Issued At field MUST not predate the validity period of the DSC.
 


### PR DESCRIPTION
This change follows the suggestion of [RFC 8949 section 3.4.2](https://datatracker.ietf.org/doc/html/rfc8949#section-3.4.2) that "an application that requires tag number 1 support may restrict the tag content to be an integer (or a floating-point value) only".

For this use-case, fractional issuance and expiry times have no function, and keeping the timestamps as integer will make validation implementations a bit less complex.

Also see the discussion at https://github.com/eu-digital-green-certificates/dgc-testdata/issues/86